### PR TITLE
Fix: handling-secrets-in-sst.md

### DIFF
--- a/_chapters/handling-secrets-in-sst.md
+++ b/_chapters/handling-secrets-in-sst.md
@@ -10,19 +10,19 @@ comments_id: handling-secrets-in-sst/2465
 
 In the [previous chapter]({% link _chapters/setup-a-stripe-account.md %}), we created a Stripe account and got a pair of keys. Including the Stripe secret key. We need this in our app but we do not want to store this secret in our code. In this chapter, we'll look at how to add secrets in SST.
 
-We will be using the [`sst secret`]({{ site.sst_url }}/docs/reference/cli/#secret){:target="_blank"} CLI to store our secrets. 
+We will be using the [`sst secrets`]({{ site.sst_url }}/docs/reference/cli/#secret){:target="_blank"} CLI to store our secrets. 
 
 {%change%} Run the following in your project root.
 
 ```bash
-$ npx sst secret set StripeSecretKey <YOUR_STRIPE_SECRET_TEST_KEY>
+$ npx sst secrets set StripeSecretKey <YOUR_STRIPE_SECRET_TEST_KEY>
 ```
 
 {%note%}
 You can specify the stage for a secret. By default, the stage is your personal stage.
 {%endnote%}
 
-You can run `npx sst secret list` to see the secrets for the current stage.
+You can run `npx sst secrets list` to see the secrets for the current stage.
 
 Now that the secret is stored, we can add it into our config using the [`Secret`]({{ site.sst_url }}/docs/component/secret/){:target="_blank"} component.
 


### PR DESCRIPTION
The correct command should be npx sst secrets (with an s at the end)