### PR TITLE
 [docs] fixing replace-in-file command and favicon generator tags

### DIFF
--- a/_chapters/add-app-favicons.md
+++ b/_chapters/add-app-favicons.md
@@ -66,10 +66,11 @@ We'll be working exclusively **in the `packages/frontend/` directory** for the r
 {%change%} Add this to the `<head>` in your `public/index.html`.
 
 ```html
-<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-<link rel="manifest" href="/site.webmanifest">
+<link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
+<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+<link rel="shortcut icon" href="/favicon.ico" />
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+<link rel="manifest" href="/site.webmanifest" />
 <meta name="msapplication-TileColor" content="#da532c">
 <meta name="theme-color" content="#ffffff">
 <meta name="description" content="A simple note taking app" />

--- a/_chapters/create-an-sst-app.md
+++ b/_chapters/create-an-sst-app.md
@@ -37,7 +37,7 @@ $ cd notes
 {%change%} Use your app name in the template.
 
 ```bash
-$ npx replace-in-file /monorepo-template/g notes **/*.* --verbose
+$ npx replace-in-file '/monorepo-template/g' 'notes' '**/*.*' --verbose
 ```
 
 {%change%} Install the dependencies.


### PR DESCRIPTION
1. Addressing this issue from the monorepo-template repo for replace-in-file npx command on project start: https://github.com/sst/monorepo-template/issues/10
2. Updated favicon html to match what the favicon generator website gives as html tags for <head>